### PR TITLE
chore(core): update core to 4.8.0 trigger order rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "convert-array-to-csv": "^2.0.0",
-        "lightning-flow-scanner-core": "4.7.0",
+        "lightning-flow-scanner-core": "4.8.0",
         "tabulator-tables": "6.3.0",
         "uuid": "^11.0.3",
         "xml2js": "^0.6.2"
@@ -12303,9 +12303,9 @@
       "peer": true
     },
     "node_modules/lightning-flow-scanner-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lightning-flow-scanner-core/-/lightning-flow-scanner-core-4.7.0.tgz",
-      "integrity": "sha512-KRIoDuppTt5XpGcs3b91qazvT8+LLPfL49gkGO88ZIgNM16xBatfmiFLbvLA7Q6pS71gEAZN5Z70/hSPdOC+7w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lightning-flow-scanner-core/-/lightning-flow-scanner-core-4.8.0.tgz",
+      "integrity": "sha512-lSBmOiwKzxZjwy5ij16a6FdzPgyEetU3wCdPml2KpmBZVyrESLU4CS5XXuFFBtWEkE8iJnGUIWhx2tFGb661fg==",
       "license": "MIT",
       "dependencies": {
         "@types/path-browserify": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
   },
   "dependencies": {
     "convert-array-to-csv": "^2.0.0",
-    "lightning-flow-scanner-core": "4.7.0",
+    "lightning-flow-scanner-core": "4.8.0",
     "tabulator-tables": "6.3.0",
     "uuid": "^11.0.3",
     "xml2js": "^0.6.2"


### PR DESCRIPTION
New & Changed Rules:
| Rule (Configuration ID) | Description |
|--------------------------|-------------|
| **Same Record Field Updates** ([`SameRecordFieldUpdates`](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/tree/master/src/main/rules/SameRecordFieldUpdates.ts)) | Much like triggers, before contexts can update the same record by accessing the trigger variables `$Record` without needing to invoke a DML. |
| **Missing Fault Path** ([`MissingFaultPath`](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/tree/master/src/main/rules/MissingFaultPath.ts)) | At times, a flow may fail to execute a configured operation as intended. By default, the flow displays an error message to the user and notifies the admin who created the flow via email. However, you can customize this behavior by incorporating a Fault Path. |
| **Trigger Order** ([`TriggerOrder`](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/tree/master/src/main/rules/TriggerOrder.ts)) | Guarantee your flow execution order with the Trigger Order property introduced in Spring '22 |
